### PR TITLE
wrong or repeated endpoint

### DIFF
--- a/source/includes/api/battle/pendingChallenges.md.erb
+++ b/source/includes/api/battle/pendingChallenges.md.erb
@@ -12,6 +12,6 @@ Allows to get count on pending challenges.
 
 ### Endpoint
 
-`GET https://api.axieinfinity.com/v1/battle/dynamicBattle/practice-quota`
+`GET https://api.axieinfinity.com/v1/battle/challenge/pending/`
 
 <%= partial "includes/api/sharedParams/authorizationHeadersParams.md" %>


### PR DESCRIPTION
the endpoint specified is the same as that for Practices Matches Limit

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->